### PR TITLE
Adding parameterization to the graphite port and pickle port elements of the diamond.conf file

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ the Graphite host and polling interval. So you can also do:
 
     class { 'diamond':
       graphite_host => 'graphite.example.com',
+      graphite_port => 2013,
       interval      => 10,
     }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -54,6 +54,8 @@ class diamond(
   $librato_apikey   = false,
   $graphite_host    = false,
   $graphite_handler = 'graphite.GraphiteHandler',
+  $graphite_port    = '2003',
+  $pickle_port      = '2004',
   $riemann_host     = false,
   $stats_host       = '127.0.0.1',
   $stats_port       = 8125,

--- a/spec/classes/diamond/diamond_spec.rb
+++ b/spec/classes/diamond/diamond_spec.rb
@@ -33,6 +33,14 @@ describe 'diamond', :type => :class do
     it { should_not contain_file('/etc/diamond/diamond.conf').with_content(/diamond.handler.librato.LibratoHandler/)}
   end
 
+  context 'with a custom graphite port and graphite pickle port' do
+    let(:params) { {'graphite_port' => '2013', 'pickle_port' => '2014'} }
+    it { should contain_file('/etc/diamond/diamond.conf').with_content(/port = 2013/)}
+    it { should contain_file('/etc/diamond/diamond.conf').with_content(/port = 2014/)}
+    it { should_not contain_file('/etc/diamond/diamond.conf').with_content(/port = 2003/)}
+    it { should_not contain_file('/etc/diamond/diamond.conf').with_content(/port = 2004/)}
+  end
+
   context 'with a riemann host' do
     let(:params) { {'riemann_host' => 'riemann.example.com'} }
     it { should contain_file('/etc/diamond/diamond.conf').with_content(/host = riemann.example.com/)}

--- a/templates/etc/diamond/diamond.conf.erb
+++ b/templates/etc/diamond/diamond.conf.erb
@@ -70,7 +70,7 @@ days = 7
 host = <%= @graphite_host %>
 
 # Port to send metrics to
-port = 2003
+port = <%= @graphite_port %>
 
 # Socket timeout (seconds)
 timeout = 15
@@ -85,7 +85,7 @@ batch = 1
 host = <%= @graphite_host %>
 
 # Port to send metrics to
-port = 2004
+port = <%= @pickle_port %>
 
 # Socket timeout (seconds)
 timeout = 15


### PR DESCRIPTION
My use case had a need for custom ports for our graphite instances, so I added that ability in
