### PR TITLE
Reduced default verbosity of logs (DEBUG+INFO -> WARNING) and disabled Archive.log by default

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -61,6 +61,8 @@ class diamond(
   $stats_port       = 8125,
   $path_prefix      = undef,
   $path_suffix      = undef,
+  $logger_level     = 'WARNING',
+  $rotate_level     = 'WARNING', 
   $extra_handlers   = [],
 ) {
   class{'diamond::install': } ->

--- a/spec/classes/diamond/diamond_spec.rb
+++ b/spec/classes/diamond/diamond_spec.rb
@@ -41,6 +41,13 @@ describe 'diamond', :type => :class do
     it { should_not contain_file('/etc/diamond/diamond.conf').with_content(/port = 2004/)}
   end
 
+  context 'with a custom logger_level and rotate_level of logging' do
+    let(:params) { {'logger_level' => 'DEBUG', 'rotate_level' => 'INFO'} }
+    it { should contain_file('/etc/diamond/diamond.conf').with_content(/level = DEBUG/)}
+    it { should contain_file('/etc/diamond/diamond.conf').with_content(/level = INFO/)}
+    it { should_not contain_file('/etc/diamond/diamond.conf').with_content(/level = WARNING/)}
+  end
+
   context 'with a riemann host' do
     let(:params) { {'riemann_host' => 'riemann.example.com'} }
     it { should contain_file('/etc/diamond/diamond.conf').with_content(/host = riemann.example.com/)}

--- a/templates/etc/diamond/diamond.conf.erb
+++ b/templates/etc/diamond/diamond.conf.erb
@@ -1,6 +1,5 @@
 <%-
 handlers = @extra_handlers
-handlers << 'diamond.handler.archive.ArchiveHandler'
 if @graphite_host then
   handlers << "diamond.handler.#{@graphite_handler}"
 end
@@ -192,14 +191,14 @@ keys = default
 [logger_root]
 
 # to increase verbosity, set DEBUG
-level = INFO
+level = <%= @logger_level %>
 handlers = rotated_file
 propagate = 1
 
 [handler_rotated_file]
 
 class = handlers.TimedRotatingFileHandler
-level = DEBUG
+level = <%= @rotate_level %>
 formatter = default
 # rotate at midnight, each day and keep 7 days
 args = ('/var/log/diamond/diamond.log', 'midnight', 1, 7)


### PR DESCRIPTION
The log file verbosity was set to DEBUG or INFO.  Both of these were too verbose and my log growth for a single server was upwards of 500 MB / day.  Now they default to WARNING and are configuraeable in the module declaration.  archive handler was disabled by default, and can be added with extra_handler
