### PR TITLE
Install Flag for Pre-Installed Diamond

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -57,33 +57,33 @@
 # [*rotate_days*]
 #   Number of days of rotate logs to keep
 #
-# [*install*]
+# [*manage_installation*]
 #   Install flag if diamond is pre-installed 
 #
 class diamond(
-  $version          = 'present',
-  $enable           = true,
-  $start            = true,
-  $interval         = 30,
-  $librato_user     = false,
-  $librato_apikey   = false,
-  $graphite_host    = false,
-  $graphite_handler = 'graphite.GraphiteHandler',
-  $graphite_port    = '2003',
-  $pickle_port      = '2004',
-  $riemann_host     = false,
-  $stats_host       = '127.0.0.1',
-  $stats_port       = 8125,
-  $path_prefix      = undef,
-  $path_suffix      = undef,
-  $logger_level     = 'WARNING',
-  $rotate_level     = 'WARNING',
-  $rotate_days      = 7,
-  $extra_handlers   = [],
-  $handlers_path    = undef,
-  $purge_collectors = false,
-  $install_from_pip = false,
-  $install = true,
+  $version             = 'present',
+  $enable              = true,
+  $start               = true,
+  $interval            = 30,
+  $librato_user        = false,
+  $librato_apikey      = false,
+  $graphite_host       = false,
+  $graphite_handler    = 'graphite.GraphiteHandler',
+  $graphite_port       = '2003',
+  $pickle_port         = '2004',
+  $riemann_host        = false,
+  $stats_host          = '127.0.0.1',
+  $stats_port          = 8125,
+  $path_prefix         = undef,
+  $path_suffix         = undef,
+  $logger_level        = 'WARNING',
+  $rotate_level        = 'WARNING',
+  $rotate_days         = 7,
+  $extra_handlers      = [],
+  $handlers_path       = undef,
+  $purge_collectors    = false,
+  $install_from_pip    = false,
+  $manage_installation = true,
 ) {
   class{'diamond::install': } ->
   class{'diamond::config': } ~>

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -5,7 +5,7 @@
 #
 class diamond::install {
 
-  if $diamond::install{
+  if $diamond::manage_installation{
     if $diamond::install_from_pip {
       case $::osfamily {
         RedHat: {


### PR DESCRIPTION
We are creating our OS images with every software products that we need are pre-installed. Then we use vagrant, which uses puppet to configure those software products. If we use the diamond package as is, we get duplicate declaration errors. That's why I introduced an install flag to skip the installation and just use the configuration. I think this change might be useful to other people as well.

Cheers,

Sercan Aktas
