### PR TITLE
Adding Solaris 11 support.

### DIFF
--- a/files/solaris/manifest/diamond.xml
+++ b/files/solaris/manifest/diamond.xml
@@ -1,0 +1,32 @@
+<?xml version='1.0'?>
+<!DOCTYPE service_bundle SYSTEM '/usr/share/lib/xml/dtd/service_bundle.dtd.1'>
+<service_bundle type='manifest' name='export'>
+  <service name='network/diamond' type='service' version='0'>
+    <create_default_instance enabled='true'/>
+    <single_instance/>
+    <dependency name='config-file' grouping='require_all' restart_on='none' type='path'>
+      <service_fmri value='file:///etc/diamond/diamond.conf'/>
+    </dependency>
+    <dependency name='filesystem-local' grouping='require_all' restart_on='none' type='service'>
+      <service_fmri value='svc:/system/filesystem/local:default'/>
+    </dependency>
+    <dependency name='network' grouping='require_all' restart_on='error' type='service'>
+      <service_fmri value='svc:/milestone/network:default'/>
+    </dependency>
+    <dependency name='fs-local' grouping='require_all' restart_on='none' type='service'>
+      <service_fmri value='svc:/system/filesystem/local'/>
+    </dependency>
+    <exec_method name='start' type='method' exec='/lib/svc/method/diamond start' timeout_seconds='60'/>
+    <exec_method name='stop' type='method' exec='/lib/svc/method/diamond stop' timeout_seconds='60'/>
+    <stability value='Evolving'/>
+    <template>
+      <common_name>
+        <loctext xml:lang='C'>Diamond Python Metrics Collection Daemon</loctext>
+      </common_name>
+      <documentation>
+        <manpage title='diamond' section='1'/>
+        <doc_link name='github.com/BrightcoveOS' uri='https://github.com/BrightcoveOS/Diamond/wiki'/>
+      </documentation>
+    </template>
+  </service>
+</service_bundle>

--- a/files/solaris/method/diamond
+++ b/files/solaris/method/diamond
@@ -1,0 +1,43 @@
+#!/sbin/sh
+
+. /lib/svc/share/smf_include.sh
+
+[[ -z "${SMF_FMRI}" ]] && exit $SMF_EXIT_ERR
+
+typeset -r CONF_FILE=/etc/diamond/diamond.conf
+[[ ! -f "${CONF_FILE}" ]] && exit $SMF_EXIT_ERR_CONFIG
+
+typeset -r DIAMOND=/usr/bin/diamond
+
+case "$1" in
+start)
+  exec $DIAMOND
+  ;;
+
+stop)
+  # stop sends sigterm first followed by sigkill
+  # smf_kill_contract <CTID> TERM 1 30
+  # sends sigterm to all process in ctid and will continue
+  # to do so for 30 seconds with interval of 5 seconds
+  # smf_kill_contract <CTID> KILL 1
+  # continues until all processes are killed.
+  # svcs -p <fmri> lists all processes in the contract.
+  # http://bnsmb.de/solaris/My_Little_SMF_FAQ.html
+  ctid=`svcprop -p restarter/contract $SMF_FMRI`
+  if [ -n "$ctid" ]; then
+    smf_kill_contract $ctid TERM 1 5
+    ret=$?
+    [ $ret -eq 1 ] && exit $SMF_EXIT_ERR_FATAL
+
+    if [ $ret -eq 2 ] ; then
+      smf_kill_contract $ctid KILL 1
+      [ $? -ne 0 ] && exit $SMF_EXIT_ERR_FATAL
+    fi
+  fi
+  ;;
+*)
+  echo "Usage: $0 {start|stop}";
+  exit $SMF_EXIT_ERR_FATAL
+  ;;
+esac
+exit $SMF_EXIT_OK

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -4,11 +4,21 @@
 #
 class diamond::service {
   $ensure = $diamond::start ? {true => running, default => stopped}
+  $service_name   = $::osfamily ? {
+    'Solaris' => 'network/diamond',
+    default   => 'diamond',
+  }
+  $manifest = $::osfamily ? {
+    'Solaris' => '/lib/svc/manifest/network/diamond.xml',
+    default   => undef,
+  }
   service { 'diamond':
     ensure     => $ensure,
+    name       => $service_name,
     enable     => $diamond::enable,
     hasstatus  => true,
     hasrestart => true,
+    manifest   => $manifest,
   }
 }
 

--- a/spec/classes/diamond/diamond_spec.rb
+++ b/spec/classes/diamond/diamond_spec.rb
@@ -183,4 +183,20 @@ describe 'diamond', :type => :class do
     it { should contain_file('/var/log/diamond')}
   end
 
+  context 'with enabling pip installation on Solaris' do
+    let (:params) { {'install_from_pip' => true} }
+    let (:facts) { {:osfamily => 'Solaris', :operatingsystemrelease => '5.11'} }
+    it { should contain_package('solarisstudio-124').that_comes_before('Package[diamond]')}
+    it { should contain_package('pip').that_comes_before('Package[diamond]')}
+    it { should contain_package('diamond').with(
+      'ensure'   => 'present',
+      'provider' => 'pip'
+      )
+    }
+    it { should contain_file('/lib/svc/method/diamond')}
+    it { should contain_file('/lib/svc/manifest/network/diamond.xml')}
+    it { should contain_file('/var/log/diamond')}
+    it { should contain_file('/ws/on11update-tools/SUNWspro/sunstudio12.1').that_comes_before('Package[diamond]')}
+  end
+
 end


### PR DESCRIPTION
  Commit will add the ability to install Diamond from pip on Solaris 11.
  Currently includes start/stop method script plus service manifest,
  both of which should probably go upstream to Diamond.
