### PR TITLE
Can't append to nil class in erb for Puppet 3.7.

### DIFF
--- a/templates/etc/diamond/diamond.conf.erb
+++ b/templates/etc/diamond/diamond.conf.erb
@@ -1,5 +1,5 @@
 <%-
-handlers = @extra_handlers
+handlers = Array(@extra_handlers)
 if @graphite_host then
   handlers << "diamond.handler.#{@graphite_handler}"
 end


### PR DESCRIPTION
Since the "extra_handlers" variable is an empty array by default, it is evaluated as nil in the ERB template. This seems to be the case only for Puppet 3.7.  Therefore, I explicitly cast the variable to an array in the template. This is the error that 3.7 users should see:

```
Error: Could not retrieve catalog from remote server: Error 400 on SERVER: Failed to parse template diamond/etc/diamond/diamond.conf.erb:
  Filepath: /etc/puppetlabs/puppet/environments/production/modules/diamond/templates/etc/diamond/diamond.conf.erb
  Line: 4
  Detail: undefined method `<<' for nil:NilClass
```
