### PR TITLE
Use an older solarisstudio

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -18,12 +18,14 @@ class diamond::install {
       Solaris: {
         case $::operatingsystemrelease {
           '5.11': {
-            ensure_resource('package', ['pip','solarisstudio-124'], {'ensure' => 'present', 'before' => Package['diamond']})
+            ensure_resource('package', ['pip','solarisstudio-122'], {'ensure' => 'present', 'before' => Package['diamond']})
+            file { ['/ws', '/ws/on11update-tools', '/ws/on11update-tools/SUNWspro']: ensure => directory, }
             file { '/ws/on11update-tools/SUNWspro/sunstudio12.1':
               ensure  => symlink,
-              target  => '/opt/solarisstudio12.4',
+              force   => true,
+              target  => '/opt/solstudio12.2',
               before  => Package['diamond'],
-              require => Package['solarisstudio-124'],
+              require => Package['solarisstudio-122'],
             }
           }
           default: {

--- a/spec/classes/diamond/diamond_spec.rb
+++ b/spec/classes/diamond/diamond_spec.rb
@@ -186,7 +186,7 @@ describe 'diamond', :type => :class do
   context 'with enabling pip installation on Solaris' do
     let (:params) { {'install_from_pip' => true} }
     let (:facts) { {:osfamily => 'Solaris', :operatingsystemrelease => '5.11'} }
-    it { should contain_package('solarisstudio-124').that_comes_before('Package[diamond]')}
+    it { should contain_package('solarisstudio-122').that_comes_before('Package[diamond]')}
     it { should contain_package('pip').that_comes_before('Package[diamond]')}
     it { should contain_package('diamond').with(
       'ensure'   => 'present',


### PR DESCRIPTION
  Solaris Studio 12.4 is not available for all versions of Solaris 11,
  so far I've found 12.2 available on all the revisions we have in
  production.  This commit will roll the module to
  Package[solarisstudio-122].
