### PR TITLE
conservative version bump for stdlib

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -46,7 +46,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.1.0"
+      "version_requirement": ">= 4.2.0"
     }
   ]
 }


### PR DESCRIPTION
will close https://github.com/garethr/garethr-diamond/issues/25

it could probably be safely bumped to 4.2.2, but I wanted to perform the most conservative update.
