### PR TITLE
Add graphite_protcol parameter to config class

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -3,23 +3,24 @@
 # The configuration of the Diamond daemon
 #
 class diamond::config {
-  $interval         = $diamond::interval
-  $graphite_host    = $diamond::graphite_host
-  $graphite_port    = $diamond::graphite_port
-  $graphite_handler = $diamond::graphite_handler
-  $pickle_port      = $diamond::pickle_port
-  $riemann_host     = $diamond::riemann_host
-  $librato_user     = $diamond::librato_user
-  $librato_apikey   = $diamond::librato_apikey
-  $path_prefix      = $diamond::path_prefix
-  $path_suffix      = $diamond::path_suffix
-  $instance_prefix  = $diamond::instance_prefix
-  $logger_level     = $diamond::logger_level
-  $rotate_level     = $diamond::rotate_level
-  $server_hostname  = $diamond::server_hostname
-  $hostname_method  = $diamond::hostname_method
-  $handlers_path    = $diamond::handlers_path
-  $rotate_days      = $diamond::rotate_days
+  $interval           = $diamond::interval
+  $graphite_host      = $diamond::graphite_host
+  $graphite_port      = $diamond::graphite_port
+  $graphite_handler   = $diamond::graphite_handler
+  $graphite_protocol  = $diamond::graphite_protocol
+  $pickle_port        = $diamond::pickle_port
+  $riemann_host       = $diamond::riemann_host
+  $librato_user       = $diamond::librato_user
+  $librato_apikey     = $diamond::librato_apikey
+  $path_prefix        = $diamond::path_prefix
+  $path_suffix        = $diamond::path_suffix
+  $instance_prefix    = $diamond::instance_prefix
+  $logger_level       = $diamond::logger_level
+  $rotate_level       = $diamond::rotate_level
+  $server_hostname    = $diamond::server_hostname
+  $hostname_method    = $diamond::hostname_method
+  $handlers_path      = $diamond::handlers_path
+  $rotate_days        = $diamond::rotate_days
   file { '/etc/diamond/diamond.conf':
     ensure  => present,
     content => template('diamond/etc/diamond/diamond.conf.erb'),


### PR DESCRIPTION
Under the Puppet future parser/4.0 language, variables used in
templates can only come from the local scope, and/or be explicitly
scoped with the scope.lookupvar function.

This adds a graphite_protocol parameter to the config class so that
the @graphite_protocol variable referenced in diamond.conf.erb will
be in the local scope.  Otherwise diamond.conf gets generated with
a blank GraphiteHandler/proto setting (when using the Puppet
future parser.)

Also updating the equals sign alignments, so all but line 10 is just
whitespace changes.
