### PR TITLE
Fix permission

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -78,12 +78,14 @@ class diamond::install {
     ensure => directory,
     owner  => root,
     group  => root,
+    mode   => '0755',
   }
 
   file { '/etc/diamond/collectors':
     ensure  => directory,
     owner   => root,
     group   => root,
+    mode    => '0755',
     purge   => $diamond::purge_collectors,
     recurse => true,
     require => File['/etc/diamond'],


### PR DESCRIPTION
Diamond use "diamond" user and group. But /etc/diamond have root user/group. On startup daemon do not have permission to read own config file.