### PR TITLE
We shouldn't install python-pip/epel directly in the module

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -7,18 +7,13 @@ class diamond::install {
 
   if $diamond::install_from_pip {
     case $::osfamily {
-      RedHat: {
-        include epel
-        ensure_resource('package', 'python-pip', {'ensure' => 'present', 'before' => Package['diamond'], 'require' => Yumrepo['epel']})
-        ensure_resource('package', ['python-configobj','gcc','python-devel'], {'ensure' => 'present', 'before' => Package['diamond'], 'require' => Package['python-pip']})
-      }
-      /^(Debian|Ubuntu)$/: {
-        ensure_resource('package', ['python-pip','python-configobj','gcc','python-dev'], {'ensure' => 'present', 'before' => Package['diamond']})
-      }
       Solaris: {
         case $::operatingsystemrelease {
           '5.11': {
-            ensure_resource('package', ['pip','solarisstudio-122'], {'ensure' => 'present', 'before' => Package['diamond']})
+            package { 'solarisstudio-122':
+              ensure => present,
+              before => Package['diamond'],
+            }
             file { ['/ws', '/ws/on11update-tools', '/ws/on11update-tools/SUNWspro']: ensure => directory, }
             file { '/ws/on11update-tools/SUNWspro/sunstudio12.1':
               ensure  => symlink,
@@ -33,42 +28,41 @@ class diamond::install {
           }
         }
       }
-      default: { fail('Unrecognized operating system') }
     }
-  package {'diamond':
-    ensure   => present,
-    provider => pip,
-  }
-  if $::osfamily == 'Solaris' {
-    # This should eventually go upstream
-    file { '/lib/svc/method/diamond':
-      source  => 'puppet:///modules/diamond/solaris/method/diamond',
-      mode    => '0755',
-      owner   => 'root',
-      group   => 'bin',
-      require => Package['diamond'],
+    package { 'diamond':
+      ensure   => present,
+      provider => pip,
     }
-    file { '/lib/svc/manifest/network/diamond.xml':
-      source  => 'puppet:///modules/diamond/solaris/manifest/diamond.xml',
-      mode    => '0444',
-      owner   => 'root',
-      group   => 'sys',
-      require => [Package['diamond'],File['/lib/svc/method/diamond']],
+    if $::osfamily == 'Solaris' {
+      # This should eventually go upstream
+      file { '/lib/svc/method/diamond':
+        source  => 'puppet:///modules/diamond/solaris/method/diamond',
+        mode    => '0755',
+        owner   => 'root',
+        group   => 'bin',
+        require => Package['diamond'],
+      }
+      file { '/lib/svc/manifest/network/diamond.xml':
+        source  => 'puppet:///modules/diamond/solaris/manifest/diamond.xml',
+        mode    => '0444',
+        owner   => 'root',
+        group   => 'sys',
+        require => [Package['diamond'],File['/lib/svc/method/diamond']],
+      }
+    } else {
+      file { '/etc/init.d/diamond':
+        mode    => '0755',
+        require => Package['diamond'],
+      }
+    }
+    file { '/var/log/diamond':
+      ensure => directory,
     }
   } else {
-    file { '/etc/init.d/diamond':
-      mode    => '0755',
-      require => Package['diamond'],
+    package { 'diamond':
+      ensure  => $diamond::version,
     }
   }
-  file { '/var/log/diamond':
-    ensure => directory,
-  }
-} else {
-  package { 'diamond':
-    ensure  => $diamond::version,
-  }
-}
 
   file { '/var/run/diamond':
     ensure => directory,
@@ -90,13 +84,21 @@ class diamond::install {
   }
 
   if $diamond::librato_user and $diamond::librato_apikey {
-    ensure_packages(['python-pip'])
-    ensure_resource('package', 'librato-metrics', {'ensure' => 'present', 'provider' => pip, 'before' => Package['python-pip']})
+    # This package should be handled outside of our module, currently no module
+    # on the forge manages the resource so we'll let it slide
+    package { 'librato-metrics':
+      ensure   => present,
+      provider => pip,
+    }
   }
 
   if $diamond::riemann_host {
-    ensure_packages(['python-pip'])
-    ensure_resource('package', 'bernhard', {'ensure' => 'present', 'provider' => pip, 'before' => Package['python-pip']})
+    # This package should be handled outside of our module, currently no module
+    # on the forge manages the resource so we'll let it slide
+    package { 'bernhard':
+      ensure   => present,
+      provider => pip,
+    }
   }
 
 }

--- a/spec/classes/diamond/diamond_spec.rb
+++ b/spec/classes/diamond/diamond_spec.rb
@@ -12,7 +12,6 @@ describe 'diamond', :type => :class do
 
     it { should contain_file('/etc/diamond/collectors').with('purge' => 'false')}
 
-    it { should_not contain_package('python-pip')}
     it { should_not contain_package('librato-metrics')}
 
     it { should_not contain_file('/etc/diamond/diamond.conf').with_content(/diamond.handler.libratohandler.LibratoHandler/)}
@@ -68,8 +67,7 @@ describe 'diamond', :type => :class do
 
   context 'with a riemann host' do
     let(:params) { {'riemann_host' => 'riemann.example.com'} }
-    it { should contain_package('python-pip')}
-    it { should contain_package('bernhard').that_comes_before('Package[python-pip]')}
+    it { should contain_package('bernhard') }
     it { should contain_file('/etc/diamond/diamond.conf').with_content(/host = riemann.example.com/)}
     it { should contain_file('/etc/diamond/diamond.conf').with_content(/diamond.handler.riemann.RiemannHandler/)}
     it { should_not contain_file('/etc/diamond/diamond.conf').with_content(/diamond.handler.libratohandler.LibratoHandler/)}
@@ -78,8 +76,7 @@ describe 'diamond', :type => :class do
 
   context 'with librato settings' do
     let(:params) { {'librato_user' => 'bob', 'librato_apikey' => 'jim'} }
-    it { should contain_package('python-pip')}
-    it { should contain_package('librato-metrics').that_comes_before('Package[python-pip]')}
+    it { should contain_package('librato-metrics') }
     it { should contain_file('/etc/diamond/diamond.conf').with_content(/diamond.handler.libratohandler.LibratoHandler/)}
     it { should contain_file('/etc/diamond/diamond.conf').with_content(/user = bob/)}
     it { should contain_file('/etc/diamond/diamond.conf').with_content(/apikey = jim/)}
@@ -143,11 +140,6 @@ describe 'diamond', :type => :class do
   context 'with enabling pip installation on RedHat' do
     let (:params) { {'install_from_pip' => true} }
     let (:facts) { {:osfamily => 'RedHat'} }
-    it { should contain_class('epel') }
-    it { should contain_package('python-pip').that_comes_before('Package[diamond]')}
-    it { should contain_package('python-configobj').that_comes_before('Package[diamond]')}
-    it { should contain_package('gcc').that_comes_before('Package[diamond]')}
-    it { should contain_package('python-devel').that_comes_before('Package[diamond]')}
     it { should contain_package('diamond').with(
       'ensure'   => 'present',
       'provider' => 'pip'
@@ -160,10 +152,6 @@ describe 'diamond', :type => :class do
   context 'with enabling pip installation on Debian' do
     let (:params) { {'install_from_pip' => true} }
     let (:facts) { {:osfamily => 'Debian'} }
-    it { should contain_package('python-pip').that_comes_before('Package[diamond]')}
-    it { should contain_package('python-configobj').that_comes_before('Package[diamond]')}
-    it { should contain_package('gcc').that_comes_before('Package[diamond]')}
-    it { should contain_package('python-dev').that_comes_before('Package[diamond]')}
     it { should contain_package('diamond').with(
       'ensure'   => 'present',
       'provider' => 'pip'
@@ -176,10 +164,6 @@ describe 'diamond', :type => :class do
   context 'with enabling pip installation on Ubuntu' do
     let (:params) { {'install_from_pip' => true} }
     let (:facts) { {:osfamily => 'Ubuntu'} }
-    it { should contain_package('python-pip').that_comes_before('Package[diamond]')}
-    it { should contain_package('python-configobj').that_comes_before('Package[diamond]')}
-    it { should contain_package('gcc').that_comes_before('Package[diamond]')}
-    it { should contain_package('python-dev').that_comes_before('Package[diamond]')}
     it { should contain_package('diamond').with(
       'ensure'   => 'present',
       'provider' => 'pip'
@@ -193,7 +177,6 @@ describe 'diamond', :type => :class do
     let (:params) { {'install_from_pip' => true} }
     let (:facts) { {:osfamily => 'Solaris', :operatingsystemrelease => '5.11'} }
     it { should contain_package('solarisstudio-122').that_comes_before('Package[diamond]')}
-    it { should contain_package('pip').that_comes_before('Package[diamond]')}
     it { should contain_package('diamond').with(
       'ensure'   => 'present',
       'provider' => 'pip'


### PR DESCRIPTION
Installing dependencies should be handled outside of the module to prevent duplicate package conflicts.

This module isn't the "authority" on installing python-pip so we shouldn't manage it. When doing this if another upstream package also tries to manage python-pip then a duplicate resource error will be created. Working around this with ensure_package only works if everyone uses that function to manage installs (and it's a scary function that we should try an avoid anyway). The best solution is to limit the scope of a module to only manage the directly related resources (in this case diamond).

This pull request removes the external dependencies and assumes that they're set up for us.

```
# Example
node default {
  include epel
  class { 'python':
    dev => true,
    pip  => true,
    require => Class['epel'],
  }
  class { 'diamond':
    require => [Class['python']. Class['epel']]
  }
}
```