### PR TITLE
Update case statement to work on future parser

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -7,7 +7,7 @@ class diamond::install {
 
   if $diamond::install_from_pip {
     case $::osfamily {
-      RedHat: {
+      'RedHat': {
         include epel
         ensure_resource('package', 'python-pip', {'ensure' => 'present', 'before' => Package['diamond'], 'require' => Yumrepo['epel']})
         ensure_resource('package', ['python-configobj','gcc','python-devel'], {'ensure' => 'present', 'before' => Package['diamond'], 'require' => Package['python-pip']})
@@ -15,7 +15,7 @@ class diamond::install {
       /^(Debian|Ubuntu)$/: {
         ensure_resource('package', ['python-pip','python-configobj','gcc','python-dev'], {'ensure' => 'present', 'before' => Package['diamond']})
       }
-      Solaris: {
+      'Solaris': {
         case $::operatingsystemrelease {
           '5.11': {
             ensure_resource('package', ['pip','solarisstudio-122'], {'ensure' => 'present', 'before' => Package['diamond']})


### PR DESCRIPTION
The future parser in Puppet 3.7+ requires that case statement cases be
strings, since in the future parser `==` does not do automatic casting.