### PR TITLE
Ubuntu15 and systemd support

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -2,5 +2,6 @@ fixtures:
   repositories:
     stdlib: git://github.com/puppetlabs/puppetlabs-stdlib.git
     epel: git://github.com/stahnma/puppet-module-epel.git
+    systemd: git://github.com/justin8/justin8-systemd.git
   symlinks:
     diamond: "#{source_dir}"

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -20,6 +20,7 @@ class diamond::config {
   $hostname_method  = $diamond::hostname_method
   $handlers_path    = $diamond::handlers_path
   $rotate_days      = $diamond::rotate_days
+  $collectors_path  = $diamond::collectors_path
   file { '/etc/diamond/diamond.conf':
     ensure  => present,
     content => template('diamond/etc/diamond/diamond.conf.erb'),

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -93,7 +93,7 @@ class diamond(
 ) {
   include systemd
 
-  case $osfamily {
+  case $::osfamily {
     'Archlinux': {
       $diamond_path = '/usr/bin/diamond'
       $collectors_path = '/usr/share/diamond/collectors/'
@@ -107,6 +107,11 @@ class diamond(
       $collectors_path = '/usr/local/share/diamond/collectors/'
     }
     'Solaris': {
+      $diamond_path = '/usr/bin/diamond'
+      $collectors_path = '/usr/share/diamond/collectors/'
+      $provider = undef
+    }
+    default: {
       $diamond_path = '/usr/bin/diamond'
       $collectors_path = '/usr/share/diamond/collectors/'
       $provider = undef

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -91,6 +91,28 @@ class diamond(
   $purge_collectors  = false,
   $install_from_pip  = false,
 ) {
+  include systemd
+
+  case $osfamily {
+    'Archlinux': {
+      $diamond_path = '/usr/bin/diamond'
+      $collectors_path = '/usr/share/diamond/collectors/'
+    }
+    'RedHat': {
+      $diamond_path = '/usr/bin/diamond'
+      $collectors_path = '/usr/share/diamond/collectors/'
+    }
+    'Debian': {
+      $diamond_path = '/usr/local/bin/diamond'
+      $collectors_path = '/usr/local/share/diamond/collectors/'
+    }
+    'Solaris': {
+      $diamond_path = '/usr/bin/diamond'
+      $collectors_path = '/usr/share/diamond/collectors/'
+      $provider = undef
+    }
+  }
+
   class{'diamond::install': } ->
   class{'diamond::config': } ~>
   class{'diamond::service': } ->

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -4,6 +4,7 @@
 # Also installed dependencies for collectors
 #
 class diamond::install {
+  $diamond_path = $diamond::diamond_path
 
   if $diamond::install_from_pip {
     case $::osfamily {
@@ -55,12 +56,20 @@ class diamond::install {
       group   => 'sys',
       require => [Package['diamond'],File['/lib/svc/method/diamond']],
     }
+  }
+
+  if $::systemd_available == 'true' {
+    file { "${::systemd::unit_path}/diamond.service":
+      content => template('diamond/diamond.service.erb'),
+      before  => Service['diamond'],
+    }
   } else {
     file { '/etc/init.d/diamond':
       mode    => '0755',
       require => Package['diamond'],
     }
   }
+
   file { '/var/log/diamond':
     ensure => directory,
   }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -12,8 +12,14 @@ class diamond::service {
     'Solaris' => '/lib/svc/manifest/network/diamond.xml',
     default   => undef,
   }
+  $provider = $::systemd_available ? {
+    'true'  => 'systemd',
+    default => undef,
+  }
+
   service { 'diamond':
     ensure     => $ensure,
+    provider   => $provider,
     name       => $service_name,
     enable     => $diamond::enable,
     hasstatus  => true,

--- a/metadata.json
+++ b/metadata.json
@@ -31,6 +31,8 @@
       "operatingsystemrelease": [
         "5.11"
       ]
+    },{
+      "operatingsystem": "Archlinux"
     }
   ],
   "requirements": [
@@ -47,6 +49,10 @@
     {
       "name": "puppetlabs/stdlib",
       "version_requirement": ">= 4.2.0"
+    },
+    {
+      "name": "justin8/systemd",
+      "version_requirement": "> 0.0.1"
     }
   ]
 }

--- a/spec/classes/diamond/diamond_spec.rb
+++ b/spec/classes/diamond/diamond_spec.rb
@@ -157,9 +157,22 @@ describe 'diamond', :type => :class do
     it { should contain_file('/var/log/diamond')}
   end
 
+  context 'with enabling pip installation on RedHat with systemd' do
+    let (:params) { {'install_from_pip' => true} }
+    let (:facts) { {
+      :osfamily => 'RedHat',
+      :systemd_available => 'true',
+    } }
+    # All other checks should be the exact same as without systemd
+    it { should contain_file('/usr/lib/systemd/system/diamond.service')}
+  end
+
   context 'with enabling pip installation on Debian' do
     let (:params) { {'install_from_pip' => true} }
-    let (:facts) { {:osfamily => 'Debian'} }
+    let (:facts) { {
+      :osfamily => 'Debian',
+      :operatingsystem => 'Debian',
+    } }
     it { should contain_package('python-pip').that_comes_before('Package[diamond]')}
     it { should contain_package('python-configobj').that_comes_before('Package[diamond]')}
     it { should contain_package('gcc').that_comes_before('Package[diamond]')}
@@ -173,9 +186,23 @@ describe 'diamond', :type => :class do
     it { should contain_file('/var/log/diamond')}
   end
 
+  context 'with enabling pip installation on Debian with systemd' do
+    let (:params) { {'install_from_pip' => true} }
+    let (:facts) { {
+      :osfamily => 'Debian',
+      :operatingsystem => 'Debian',
+      :systemd_available => 'true',
+    } }
+    # All other checks should be the exact same as without systemd
+    it { should contain_file('/lib/systemd/system/diamond.service')}
+  end
+
   context 'with enabling pip installation on Ubuntu' do
     let (:params) { {'install_from_pip' => true} }
-    let (:facts) { {:osfamily => 'Ubuntu'} }
+    let (:facts) { {
+      :osfamily => 'Debian',
+      :operatingsystem => 'Ubuntu',
+    } }
     it { should contain_package('python-pip').that_comes_before('Package[diamond]')}
     it { should contain_package('python-configobj').that_comes_before('Package[diamond]')}
     it { should contain_package('gcc').that_comes_before('Package[diamond]')}
@@ -187,6 +214,17 @@ describe 'diamond', :type => :class do
     }
     it { should contain_file('/etc/init.d/diamond')}
     it { should contain_file('/var/log/diamond')}
+  end
+
+  context 'with enabling pip installation on Ubuntu with systemd' do
+    let (:params) { {'install_from_pip' => true} }
+    let (:facts) { {
+      :osfamily => 'Debian',
+      :operatingsystem => 'Ubuntu',
+      :systemd_available => 'true',
+    } }
+    # All other checks should be the exact same as without systemd
+    it { should contain_file('/lib/systemd/system/diamond.service')}
   end
 
   context 'with enabling pip installation on Solaris' do

--- a/templates/diamond.service.erb
+++ b/templates/diamond.service.erb
@@ -1,0 +1,9 @@
+[Unit]
+Description=Diamond daemon
+After=network.target
+
+[Service]
+ExecStart=<%= @diamond_path %> --foreground --log-stdout
+
+[Install]
+WantedBy=multi-user.target

--- a/templates/etc/diamond/diamond.conf.erb
+++ b/templates/etc/diamond/diamond.conf.erb
@@ -33,7 +33,7 @@ group =
 pid_file = /var/run/diamond.pid
 
 # Directory to load collector modules from
-collectors_path = /usr/share/diamond/collectors/
+collectors_path = <%= @collectors_path %>
 
 # Directory to load collector configs from
 collectors_config_path = /etc/diamond/collectors/


### PR DESCRIPTION
Added support for systemd systems with pip installs (Fedora 14+, RHEL 7+, Debian 8+, Ubuntu 15.04+ &  Archlinux)

Added rspec tests for the service files.

Fixed collector paths for ubuntu pip installs (they go to /usr/local/share instead of /usr/share like most other OSes).

Fixed spec tests that had osfamily => 'Ubuntu'. Should've been osfamily => 'Debian', operatingsystem => 'Ubuntu' like on real systems.