### PR TITLE
Add header param

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,23 @@ diamond::collector { 'RabbitMQCollector':
 }
 ```
 
+Some collectors support header section, for example the ProcessResources collector
+
+```puppet
+diamond::collector {'ProcessResourcesCollector':
+  options => {
+    'unit'         => 'B',
+    'cpu_interval' => '0.1',
+  },
+  header_section => '[process]',
+  sections => {
+    '[[diamond]]' => {
+      'selfmon' => 'True',
+    },
+  }
+}
+```
+
 Diamond supports a number of different handlers, for the moment this
 module supports only the Graphite, Librato and Riemann handers. Pull request
 happily accepted to add others.

--- a/manifests/collector.pp
+++ b/manifests/collector.pp
@@ -11,7 +11,8 @@
 #   Each section can have its own options
 define diamond::collector (
   $options = undef,
-  $sections = undef
+  $header_section = undef,
+  $sections = undef,
 ) {
   include diamond
 

--- a/templates/etc/diamond/collectors/collector.conf.erb
+++ b/templates/etc/diamond/collectors/collector.conf.erb
@@ -4,6 +4,11 @@ enabled=True
 <%= "#{k} = #{@options[k]}" %>
 <%   end
    end -%>
+
+<% if defined?(@header_section) -%>
+<%= @header_section %>
+<% end -%>
+
 <% if defined?(@sections)
      @sections.keys.each do |k| -%>
 


### PR DESCRIPTION
This adds a param to the collector. It mainly allows for collectors like ProcessResourcesCollector to work, since it requires a [process header](https://github.com/python-diamond/Diamond/wiki/collectors-ProcessResourcesCollector) above the sections.
