### PR TITLE
Include needed variables in diamond::config

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -3,23 +3,26 @@
 # The configuration of the Diamond daemon
 #
 class diamond::config {
-  $interval         = $diamond::interval
-  $graphite_host    = $diamond::graphite_host
-  $graphite_port    = $diamond::graphite_port
-  $graphite_handler = $diamond::graphite_handler
-  $pickle_port      = $diamond::pickle_port
-  $riemann_host     = $diamond::riemann_host
-  $librato_user     = $diamond::librato_user
-  $librato_apikey   = $diamond::librato_apikey
-  $path_prefix      = $diamond::path_prefix
-  $path_suffix      = $diamond::path_suffix
-  $instance_prefix  = $diamond::instance_prefix
-  $logger_level     = $diamond::logger_level
-  $rotate_level     = $diamond::rotate_level
-  $server_hostname  = $diamond::server_hostname
-  $hostname_method  = $diamond::hostname_method
-  $handlers_path    = $diamond::handlers_path
-  $rotate_days      = $diamond::rotate_days
+  $interval          = $diamond::interval
+  $graphite_host     = $diamond::graphite_host
+  $graphite_port     = $diamond::graphite_port
+  $graphite_protocol = $diamond::graphite_protocol
+  $graphite_handler  = $diamond::graphite_handler
+  $pickle_port       = $diamond::pickle_port
+  $riemann_host      = $diamond::riemann_host
+  $librato_user      = $diamond::librato_user
+  $librato_apikey    = $diamond::librato_apikey
+  $path_prefix       = $diamond::path_prefix
+  $path_suffix       = $diamond::path_suffix
+  $instance_prefix   = $diamond::instance_prefix
+  $logger_level      = $diamond::logger_level
+  $rotate_level      = $diamond::rotate_level
+  $server_hostname   = $diamond::server_hostname
+  $stats_host        = $diamond::stats_host
+  $stats_port        = $diamond::stats_port
+  $hostname_method   = $diamond::hostname_method
+  $handlers_path     = $diamond::handlers_path
+  $rotate_days       = $diamond::rotate_days
   file { '/etc/diamond/diamond.conf':
     ensure  => present,
     content => template('diamond/etc/diamond/diamond.conf.erb'),


### PR DESCRIPTION
Explicitly pull graphite_protocol, stats_host, stats_port variables into diamond::config so that the erb template will have them in scope.

This is required for the template to have access to those variables in puppet 4. Puppet 3 appears to find them anyway, so it hasn't been a problem before.

note: we (puppet labs ops) are running this code in production already so I'm fairly confident that it doesn't break things.