### PR TITLE
Update travis coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,26 @@
 language: ruby
 bundler_args: --without development
 before_install: rm Gemfile.lock || true
+sudo: false
 rvm:
-  - 1.8.7
   - 1.9.3
   - 2.0.0
   - 2.1.0
+  - jruby-19mode
 script: bundle exec rake test
 env:
   - PUPPET_VERSION="~> 3.5.0"
   - PUPPET_VERSION="~> 3.6.0"
   - PUPPET_VERSION="~> 3.7.0"
+  - PUPPET_VERSION="~> 3.8.2"
+  - PUPPET_VERSION="~> 4.2.2"
+matrix:
+  exclude:
+  - rvm: 1.9.3
+    env: PUPPET_VERSION="~> 4.2.2"
+  - rvm: 2.0.0
+    env: PUPPET_VERSION="~> 4.2.2"
+  - rvm: 2.1.0
+    env: PUPPET_VERSION="~> 4.2.2"
+  allow_failures:
+    - env: PUPPET_VERSION="~> 4.2.2"


### PR DESCRIPTION
Remove ruby 1.8.7 from travis testing, and add puppet 3.8.2 and 4.2.2.

The 1.8.7 tests have been broken for some time and effectively cause this to have no usable test coverage for PRs because all tests fail.

Also configures travis to use their new containerized build system, which is a lot faster.